### PR TITLE
Update default code theme in light mode

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,7 +8,8 @@ module.exports = {
   projectName: "react-toastify",
   themeConfig: {
     prism: {
-      theme: require("prism-react-renderer/themes/dracula"),
+      theme: require("prism-react-renderer/themes/github"),
+      darkTheme: require("prism-react-renderer/themes/dracula"),
     },
     navbar: {
       title: "React-Toastify",


### PR DESCRIPTION
## Description

- Added light theme for code snippets on light mode. This fixes #3 
- Now the **Copy** badge is visible nice and clear
- Previously used dark theme is now visible only in dark mode.

Thanks a lot!