### PR TITLE
Fix incorrect toast emitted for dark toast

### DIFF
--- a/src/components/ToastCode.tsx
+++ b/src/components/ToastCode.tsx
@@ -16,6 +16,8 @@ function getType(type: string) {
       return "toast.info";
     case "warning":
       return "toast.warn";
+    case "dark":
+      return "toast.dark";
   }
 }
 


### PR DESCRIPTION
When the dark toast type is selected, the code emitted now corresponds to a dark toast as opposed to the default.

##### Before
<img width="859" alt="Before change" src="https://user-images.githubusercontent.com/33874484/92465993-52e8dd00-f1c7-11ea-88c7-a562f850bc4a.png">

##### After
<img width="847" alt="After change" src="https://user-images.githubusercontent.com/33874484/92466033-62682600-f1c7-11ea-9b5c-a6db8b61f2e6.png">
