### PR TITLE
Fix minor grammatical error

### DIFF
--- a/docs/migrate-to-v8.md
+++ b/docs/migrate-to-v8.md
@@ -99,7 +99,7 @@ toast.promise(
       },
       error: {
         render({data}){
-          // When the promise reject, data will contains the error
+          // When the promise is rejected, data will contain the error
           return <MyErrorComponent message={data.message} />
         }
       }


### PR DESCRIPTION
Fixes a minor grammatical error found on [this](https://fkhadra.github.io/react-toastify/migration-v8) page.

**Before:**
> When the promise reject, data will contains the error

**After:**
> When the promise is rejected, data will contain the error