### PR TITLE
type option in api docs

### DIFF
--- a/docs/api/toast.md
+++ b/docs/api/toast.md
@@ -12,6 +12,7 @@ sidebar_label: toast
 
 | Options           | Type              | Description                                                                                         |
 |-------------------|-------------------|-----------------------------------------------------------------------------------------------------|
+| type              | string            | One of info, success, warning, error                                                                |
 | position          | string            | One of top-right, top-center, top-left, bottom-right, bottom-center, bottom-left                    |
 | onOpen            | function          | Called when the notification appear                                                                 |
 | onClose           | function          | Called when the notification disappear                                                              |


### PR DESCRIPTION
The type option is mentioned a few places in the docs, but isn't actually documented.

This PR adds it to the toast() API page.