### PR TITLE
docs: update installation.md to raise minimum React version to 18

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,7 +6,7 @@ sidebar_label: Installation
 
 ## Requirements
 
-- [React](https://reactjs.org) version >= 16.8 or above 
+- [React](https://reactjs.org) version >= 18 or above 
 
 ## Installation
 


### PR DESCRIPTION
In order of: https://fkhadra.github.io/react-toastify/migration-v10#react-18-is-the-minimum-required-version-but