### PR TITLE
fix ContainerCode.tsx

### DIFF
--- a/src/components/ContainerCode.tsx
+++ b/src/components/ContainerCode.tsx
@@ -73,7 +73,7 @@ export const ContainerCode: React.FC<ContainerCodeProps> = ({
       </div>
       <div>
         <Element kind={1}>transition</Element>
-        {`: ${selectedTransitions[transition]}`},
+        {`={${selectedTransitions[transition]}}`}
       </div>
       <div>
         <span>{`/>`}</span>


### PR DESCRIPTION
Changed from `:` to `=`.

## before
![image](https://github.com/fkhadra/react-toastify-doc/assets/49489155/f0726b8f-4524-4276-bc12-89f1bd019c33)


## after
![image](https://github.com/fkhadra/react-toastify-doc/assets/49489155/df096098-445c-4560-9ba6-a1ddf57ab379)
