### PR TITLE
Update container.tsx, fixed an syntax error shown on the website's in…

### DIFF
--- a/src/components/ContainerCode.tsx
+++ b/src/components/ContainerCode.tsx
@@ -73,7 +73,7 @@ export const ContainerCode: React.FC<ContainerCodeProps> = ({
       </div>
       <div>
         <Element kind={1}>transition</Element>
-        {`: ${selectedTransitions[transition]}`},
+        {`= ${selectedTransitions[transition]}`},
       </div>
       <div>
         <span>{`/>`}</span>


### PR DESCRIPTION


There was a syntax error where there was a colon after the transition. If my fellow coders copied that, they would also encounter a syntax error. So, i thought i might contribute and fix a small typo.


<img width="222" alt="image" src="https://github.com/fkhadra/react-toastify-doc/assets/100614956/2d9eae77-a303-4f32-8893-ccdcaa16d33a">




