### PR TITLE
Add setup section to the installation page

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,6 +20,11 @@ With yarn:
 yarn add react-toastify
 ```
 
+## Setup
+
+- Add `import 'react-toastify/dist/ReactToastify.css';` on your main page or layout
+- Add `<ToastContainer />` to your application tree
+
 ## The gist
 
 ```jsx


### PR DESCRIPTION
Add setup section to make it clear the user should add the css somewhere in their root page or layout.