### PR TITLE
how to style link fixed

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -24,7 +24,7 @@ By default, all toasts will inherit ToastContainer's props. Props defined on toa
 
 ## Make it yours
 
-Super easy to customize, it can blend into any design system. Check the [How to style](./how-to-style) guide for more details.
+Super easy to customize, it can blend into any design system. Check the [How to style](/how-to-style) guide for more details.
 
 ![style](./customization.png)
 


### PR DESCRIPTION
currently, this "How to style" links to /introduction/how-to-style

![image](https://github.com/user-attachments/assets/2093c626-4a1a-4708-ad99-d06236812768)
 
![image](https://github.com/user-attachments/assets/d6ffd1a4-29d4-49e5-b6bd-97bd79a40b40)

but it works as expected when i run it on local, linking to expected /how-to-style page

base URL is defined as /react-toastify/ . I think the problem is local appends the relative path to the default, but deployed website appends the relative path to the current path, which results in /introduction/how-to-style

i believe simply changing to absolute path will ensure that it will link to the correct page.
just like use-your-own-component link in how to style page, which you have set as absolute path.
